### PR TITLE
Add max_allowed_packet option to fix dsf-prod backup

### DIFF
--- a/mysql2s3.js
+++ b/mysql2s3.js
@@ -34,6 +34,7 @@ const config = {
 			host: process.env.MYSQL_HOST,
 			user: process.env.MYSQL_USER,
 			password: process.env.MYSQL_PWD,
+			max_allowed_packet: process.env.MAX_ALLOWED_PACKET || "4194304",
 		},
 		s3: {
 			bucket: process.env.AWS_S3_BUCKET,
@@ -301,6 +302,7 @@ const _getMySqlDump = (config) => {
 			'-h', config.host,
 			'-u', config.user,
 			'--single-transaction',
+			'--max_allowed_packet', config.max_allowed_packet,
 			config.database
 		],
 		{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mysql2s3",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "description": "Dump MySQL databases to AWS S3",
   "main": "mysql2s3.js",
   "scripts": {


### PR DESCRIPTION
Ajouté l'option max_allowed_packet parce que les backups en dsf-prod crashent parfois. La valeur par défaut quand l'option n'est pas là c'est 4194304 (4Mb).