### PR TITLE
Improve performance: Increase default max_allowed_packet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
-FROM node:14 AS builder
-MAINTAINER "na-qc@equisoft.com"
+FROM node:18 AS builder
 
 WORKDIR /code
 COPY ["package.json", ".yarnclean", "yarn.lock", "/code/"]
 RUN yarn install && yarn autoclean --force && yarn cache clean
 
-
-FROM node:14-slim
+FROM node:18-slim
 
 COPY --from=builder /code /code
 WORKDIR /code

--- a/mysql2s3.js
+++ b/mysql2s3.js
@@ -34,7 +34,7 @@ const config = {
 			host: process.env.MYSQL_HOST,
 			user: process.env.MYSQL_USER,
 			password: process.env.MYSQL_PWD,
-			max_allowed_packet: process.env.MAX_ALLOWED_PACKET || "4194304",
+			max_allowed_packet: process.env.MAX_ALLOWED_PACKET || "256000000",
 		},
 		s3: {
 			bucket: process.env.AWS_S3_BUCKET,
@@ -307,6 +307,7 @@ const _getMySqlDump = (config) => {
 			'-u', config.user,
 			'--single-transaction',
 			'--max_allowed_packet', config.max_allowed_packet,
+			'--skip-lock-tables',
 			config.database
 		],
 		{


### PR DESCRIPTION
Investigation pourquoi le mysqldump prend 13h+. Probablement un trop faible max_allowed_packet, on pourrait l'augmenter uniquement dans les environnements en question, mais 4MB c'est trop faible pour tout nos environnements.

+ nodejs update
+ Add --skip-lock-tables

tester en local.

Je vais releasé la version 1.0.0, parce que je n'aime pas avoir des versions beta.