### PR TITLE
DOPS-4084: tentative de fix de mysqldump export

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ WORKDIR /code
 COPY ["package.json", ".yarnclean", "yarn.lock", "/code/"]
 RUN yarn install && yarn autoclean --force && yarn cache clean
 
-FROM node:18-slim
+FROM node:20-alpine
 
 COPY --from=builder /code /code
 WORKDIR /code
 COPY [".env", "mysql2s3.js", "README.md", "LICENSE", "/code/"]
 
-RUN apt update && apt install -y mariadb-client --no-install-recommends --no-install-suggests && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+RUN apk add mysql-client && rm -f /var/cache/apk/*
 
 USER 1000
 CMD node --expose-gc ./mysql2s3.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=builder /code /code
 WORKDIR /code
 COPY [".env", "mysql2s3.js", "README.md", "LICENSE", "/code/"]
 
-RUN apk add mysql-client && rm -f /var/cache/apk/*
+RUN apk add mariadb-client && rm -f /var/cache/apk/*
 
 USER 1000
 CMD node --expose-gc ./mysql2s3.js


### PR DESCRIPTION
Ce fix installe la version `mysqldump  Ver 10.19 Distrib 10.11.5-MariaDB, for Linux (x86_64)` qui contient le fix de la query d'`INSERT`