### PR TITLE
DOPS-4215 Fix config load

### DIFF
--- a/mysql2s3.js
+++ b/mysql2s3.js
@@ -49,10 +49,10 @@ const config = {
 			level: process.env.COMPRESSION_LEVEL,
 			threads: process.env.COMPRESSION_THREADS,
 		},
-		sentry: {
-			dsn: process.env.SENTRY_DSN,
-			monitor_slug: process.env.SENTRY_MONITOR_SLUG,
-		}
+	},
+	sentry: {
+		dsn: process.env.SENTRY_DSN,
+		monitor_slug: process.env.SENTRY_MONITOR_SLUG,
 	}
 };
 


### PR DESCRIPTION
Sentry était sous backup au lieu d'être directement dans le root de config.