### PR TITLE
DOPS-5813: use mysql client instead mariadb client to run mysqldump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=builder /code /code
 WORKDIR /code
 COPY [".env", "mysql2s3.js", "README.md", "LICENSE", "/code/"]
 
-RUN apk add mariadb-client && rm -f /var/cache/apk/*
+RUN apk add mysql-client && rm -f /var/cache/apk/*
 
 USER 1000
 CMD node --expose-gc ./mysql2s3.js

--- a/mysql2s3.js
+++ b/mysql2s3.js
@@ -349,6 +349,7 @@ const _getMySqlDump = (config) => {
 			'--single-transaction',
 			'--max_allowed_packet', config.max_allowed_packet,
 			'--skip-lock-tables',
+			'----set-gtid-purged=OFF',
 			config.database
 		],
 		{


### PR DESCRIPTION
This pull request includes updates to the Dockerfile and the `mysql2s3.js` script to improve compatibility and functionality. The most important changes involve replacing the MariaDB client with the MySQL client in the Dockerfile and adding a new MySQL dump option in the script.

### Dockerfile updates:
* Replaced `mariadb-client` with `mysql-client` in the Dockerfile to ensure compatibility with MySQL-specific features.

### `mysql2s3.js` updates:
* Added the `--set-gtid-purged=OFF` option to the MySQL dump command to ensure compatibility with GTID-based replication setups.